### PR TITLE
Added a dispose function to delete simulator object

### DIFF
--- a/projects/04_drone/ae353_drone.py
+++ b/projects/04_drone/ae353_drone.py
@@ -697,3 +697,20 @@ class Simulator:
             return p
         else:
             return None
+
+    def dispose(self):
+        '''
+        This function will reset the PyBullet Simulation, setting it up to be reconnected to and then disconnects from the server.  This will close the simulation window.
+        The function is equipped with try/catch so that no errors will be thrown when a step has already been taken.  For example, if the user already closes the GUI window, it would throw an error without the catch statement.
+        '''
+        # Remove all objects from simulation
+        try:
+            pybullet.resetSimulation()
+        except pybullet.error:
+            pass
+
+        # Clean up connection if not already done
+        try:
+            pybullet.disconnect()
+        except pybullet.error:
+            pass 


### PR DESCRIPTION
Added a dispose function.  This function will allow the user to close the simulation window and create a new instance.  Simply run the command `simulator.dispose()` in the Jupyter Notebook.  It will work if the user closes the GUI window or not.  It also works with the GUI on or off.  The function is also equipped with extensive try/catch statements to avoid errors being thrown.

I can only test on Windows, would love to confirm that the function works on Macs.

- Nicholas Hall <nihall2@illinois.edu>